### PR TITLE
Remove public_network on EKS

### DIFF
--- a/eks-box/Vagrantfile
+++ b/eks-box/Vagrantfile
@@ -19,9 +19,6 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = settings["vm"]["hostname"]
   config.vm.box = settings["vm"]["image"]
   config.vm.box_check_update = false
-  config.vm.network :public_network,
-    :bridge => settings["vm"]["bridge"],
-    :dev => settings["vm"]["bridge"]
   config.vm.provider :libvirt do |libvirt|
     libvirt.memory = settings["vm"]["memory"]
     libvirt.cpus = settings["vm"]["cpus"]

--- a/eks-box/env.yml
+++ b/eks-box/env.yml
@@ -5,7 +5,6 @@ vm:
   memory: 2048
   vmname: aws-eks-opensuseTW
   hostname: aws-eks-opensuseTW
-  bridge: # Name of you public bridge device
   
 kubectl:
   version: 1.22.1


### PR DESCRIPTION
A public network is not really needed for the EKS VM. And as the current code doesn't work on all libvirt configurations, it's easier to simply remove it.