### PR TITLE
Bump Epinio CLI version and fix var name

### DIFF
--- a/aks-box/env.yml
+++ b/aks-box/env.yml
@@ -21,4 +21,4 @@ azure:
   provision_k8s: false
 
 epinio:
-  version: 0.5.2
+  version: 0.6.1

--- a/eks-box/env.yml
+++ b/eks-box/env.yml
@@ -25,4 +25,4 @@ aws:
   provision_k8s: false
 
 epinio:
-  version: 0.5.2
+  version: 0.6.1

--- a/gke-box/env.yml
+++ b/gke-box/env.yml
@@ -10,7 +10,7 @@ kubectl:
   version: 1.22.1
 
 google-sdk:
-  version: 361.0.0
+  version: 377.0.0
   
 helm:
   version: 3.7.0
@@ -21,7 +21,7 @@ gke:
   node_count: 1
   vm_size: n1-standard-2
   disk_size: 40
-  provision_gke: false
+  provision_k8s: false
 
 epinio:
-  version: 0.5.2
+  version: 0.6.1

--- a/k3s-epinio-1-node/env.yml
+++ b/k3s-epinio-1-node/env.yml
@@ -13,9 +13,9 @@ helm:
   version: 3.7.0
 
 epinio:
-  cli_version: 0.5.2
+  cli_version: 0.6.1
   helm_chart_dev_version: false
 
 rancher:
   provision_rancher: true
-  dashboard_version: epinio-v0.5.0
+  dashboard_version: epinio-v0.6.0


### PR DESCRIPTION
Bump some versions and fix an issue with a wrong variable name to provision k8s automatically.